### PR TITLE
Correct README submodule initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ First clone the repo.
 git clone https://github.com/kernelize-ai/nexus.git
 cd nexus
 ## ??
-git submodule init --update
+git submodule update --init
 ```
 
 Then create the environment.


### PR DESCRIPTION
Currently, --update is not a flag that can be passed to git submodule init. 

This PR updates the README documentation to specify the correct submodule initialization command.
