### PR TITLE
Ignore python virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ __pycache__/
 
 *.egg-info
 
+.venv
+


### PR DESCRIPTION
Currently, when a developer is working on nexus, .venv, which is needed for building and running nexus is consistently marked as an untracked file.

This PR adds it to the ignore file so it is not mentioned as an untracked file.