### PR TITLE
Add kernel.metal file and update README documentation

### DIFF
--- a/test/pynexus/README.md
+++ b/test/pynexus/README.md
@@ -1,0 +1,15 @@
+
+## Example to generate kernel.so
+
+
+To generate LLVM IR:
+```script
+xcrun -sdk macosx metal -c kernel.metal -o kernel.ir
+llvm-dis kernel.ir -o kernel.ll
+```
+
+To generate SO library binary:
+```script
+xcrun -sdk macosx metal -c kernel.metal -o kernel.ir
+xcrun -sdk macosx metallib kernel.ir -o kernel.so
+```

--- a/test/pynexus/kernel.metal
+++ b/test/pynexus/kernel.metal
@@ -1,0 +1,9 @@
+#include <metal_stdlib>
+using namespace metal;
+kernel void add_vectors(device const float* inA [[buffer(0)]],
+                        device const float* inB [[buffer(1)]],
+                        device float* result [[buffer(2)]],
+                        uint id [[thread_position_in_grid]])
+{
+    result[id] = inA[id] + inB[id];
+}


### PR DESCRIPTION
This PR explicitly adds a kernel.metal file to the repo and documentation to produce the kernel metallib used by nexus