### PR TITLE
Add Linux support for CUDA runtime discovery

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,7 +1,21 @@
 
 if(LINUX)
 
-    add_subdirectory(cuda)
+    include(CheckLanguage)
+    check_language(CUDA)
+
+    if(CMAKE_CUDA_COMPILER)
+
+        enable_language(CUDA)
+        set(CUDA_AVAILABLE TRUE)
+        add_subdirectory(cuda)
+
+    else()
+
+        set(CUDA_AVAILABLE FALSE)
+
+    endif()
+
     add_subdirectory(hip)
 
 elseif(MACOS)


### PR DESCRIPTION
This PR updates the plugin cmakelists so that when the platform is Linux, it checks if CUDA is installed and brings the plugin in to compilation