### PR TITLE
Use explicit enum to string function for cpu uarch

### DIFF
--- a/plugins/cpu/cpu_runtime.cpp
+++ b/plugins/cpu/cpu_runtime.cpp
@@ -13,6 +13,8 @@
 #include <optional>
 #include <vector>
 
+#include "uarch_to_string.h"
+
 #define NXSAPI_LOGGING
 #include <nexus-api.h>
 
@@ -106,9 +108,9 @@ nxsGetDeviceProperty(nxs_int device_id, nxs_uint device_property_id,
     case NP_Type:
       return rt::getPropertyStr(property_value, property_value_size, "cpu");
     case NP_Architecture: {
-      auto archName = magic_enum::enum_name(device->core->uarch);
+      auto archName = nxs::cpu_util::uarch_to_string(device->core->uarch);
       return rt::getPropertyStr(property_value, property_value_size,
-                                archName.data());
+                                archName);
     }
 
     default:

--- a/plugins/cpu/uarch_to_string.h
+++ b/plugins/cpu/uarch_to_string.h
@@ -1,0 +1,277 @@
+#include <cpuinfo.h>
+
+#include <string>
+
+namespace nxs::cpu_util {
+
+// Note: keep in sync with `cpuinfo/tools/cpu-info.c`
+std::string uarch_to_string(enum cpuinfo_uarch uarch) {
+	switch (uarch) {
+		case cpuinfo_uarch_unknown:
+			return "unknown";
+		case cpuinfo_uarch_p5:
+			return "P5";
+		case cpuinfo_uarch_quark:
+			return "Quark";
+		case cpuinfo_uarch_p6:
+			return "P6";
+		case cpuinfo_uarch_dothan:
+			return "Dothan";
+		case cpuinfo_uarch_yonah:
+			return "Yonah";
+		case cpuinfo_uarch_conroe:
+			return "Conroe";
+		case cpuinfo_uarch_penryn:
+			return "Penryn";
+		case cpuinfo_uarch_nehalem:
+			return "Nehalem";
+		case cpuinfo_uarch_sandy_bridge:
+			return "Sandy Bridge";
+		case cpuinfo_uarch_ivy_bridge:
+			return "Ivy Bridge";
+		case cpuinfo_uarch_haswell:
+			return "Haswell";
+		case cpuinfo_uarch_broadwell:
+			return "Broadwell";
+		case cpuinfo_uarch_sky_lake:
+			return "Sky Lake";
+		case cpuinfo_uarch_palm_cove:
+			return "Palm Cove";
+		case cpuinfo_uarch_sunny_cove:
+			return "Sunny Cove";
+		case cpuinfo_uarch_willow_cove:
+			return "Willow Cove";
+		case cpuinfo_uarch_willamette:
+			return "Willamette";
+		case cpuinfo_uarch_prescott:
+			return "Prescott";
+		case cpuinfo_uarch_bonnell:
+			return "Bonnell";
+		case cpuinfo_uarch_saltwell:
+			return "Saltwell";
+		case cpuinfo_uarch_silvermont:
+			return "Silvermont";
+		case cpuinfo_uarch_gracemont:
+			return "Gracemont";
+		case cpuinfo_uarch_crestmont:
+			return "Crestmont";
+		case cpuinfo_uarch_airmont:
+			return "Airmont";
+		case cpuinfo_uarch_goldmont:
+			return "Goldmont";
+		case cpuinfo_uarch_goldmont_plus:
+			return "Goldmont Plus";
+		case cpuinfo_uarch_darkmont:
+			return "Darkmont";
+		case cpuinfo_uarch_knights_ferry:
+			return "Knights Ferry";
+		case cpuinfo_uarch_knights_corner:
+			return "Knights Corner";
+		case cpuinfo_uarch_knights_landing:
+			return "Knights Landing";
+		case cpuinfo_uarch_knights_hill:
+			return "Knights Hill";
+		case cpuinfo_uarch_knights_mill:
+			return "Knights Mill";
+		case cpuinfo_uarch_k5:
+			return "K5";
+		case cpuinfo_uarch_k6:
+			return "K6";
+		case cpuinfo_uarch_k7:
+			return "K7";
+		case cpuinfo_uarch_k8:
+			return "K8";
+		case cpuinfo_uarch_k10:
+			return "K10";
+		case cpuinfo_uarch_bulldozer:
+			return "Bulldozer";
+		case cpuinfo_uarch_piledriver:
+			return "Piledriver";
+		case cpuinfo_uarch_steamroller:
+			return "Steamroller";
+		case cpuinfo_uarch_excavator:
+			return "Excavator";
+		case cpuinfo_uarch_zen:
+			return "Zen";
+		case cpuinfo_uarch_zen2:
+			return "Zen 2";
+		case cpuinfo_uarch_zen3:
+			return "Zen 3";
+		case cpuinfo_uarch_zen4:
+			return "Zen 4";
+		case cpuinfo_uarch_zen5:
+			return "Zen 5";
+		case cpuinfo_uarch_geode:
+			return "Geode";
+		case cpuinfo_uarch_bobcat:
+			return "Bobcat";
+		case cpuinfo_uarch_jaguar:
+			return "Jaguar";
+		case cpuinfo_uarch_puma:
+			return "Puma";
+		case cpuinfo_uarch_xscale:
+			return "XScale";
+		case cpuinfo_uarch_arm7:
+			return "ARM7";
+		case cpuinfo_uarch_arm9:
+			return "ARM9";
+		case cpuinfo_uarch_arm11:
+			return "ARM11";
+		case cpuinfo_uarch_cortex_a5:
+			return "Cortex-A5";
+		case cpuinfo_uarch_cortex_a7:
+			return "Cortex-A7";
+		case cpuinfo_uarch_cortex_a8:
+			return "Cortex-A8";
+		case cpuinfo_uarch_cortex_a9:
+			return "Cortex-A9";
+		case cpuinfo_uarch_cortex_a12:
+			return "Cortex-A12";
+		case cpuinfo_uarch_cortex_a15:
+			return "Cortex-A15";
+		case cpuinfo_uarch_cortex_a17:
+			return "Cortex-A17";
+		case cpuinfo_uarch_cortex_a32:
+			return "Cortex-A32";
+		case cpuinfo_uarch_cortex_a35:
+			return "Cortex-A35";
+		case cpuinfo_uarch_cortex_a53:
+			return "Cortex-A53";
+		case cpuinfo_uarch_cortex_a55r0:
+			return "Cortex-A55r0";
+		case cpuinfo_uarch_cortex_a55:
+			return "Cortex-A55";
+		case cpuinfo_uarch_cortex_a57:
+			return "Cortex-A57";
+		case cpuinfo_uarch_cortex_a65:
+			return "Cortex-A65";
+		case cpuinfo_uarch_cortex_a72:
+			return "Cortex-A72";
+		case cpuinfo_uarch_cortex_a73:
+			return "Cortex-A73";
+		case cpuinfo_uarch_cortex_a75:
+			return "Cortex-A75";
+		case cpuinfo_uarch_cortex_a76:
+			return "Cortex-A76";
+		case cpuinfo_uarch_cortex_a77:
+			return "Cortex-A77";
+		case cpuinfo_uarch_cortex_a78:
+			return "Cortex-A78";
+		case cpuinfo_uarch_cortex_a510:
+			return "Cortex-A510";
+		case cpuinfo_uarch_cortex_a710:
+			return "Cortex-A710";
+		case cpuinfo_uarch_cortex_a715:
+			return "Cortex-A715";
+		case cpuinfo_uarch_cortex_x1:
+			return "Cortex-X1";
+		case cpuinfo_uarch_cortex_x2:
+			return "Cortex-X2";
+		case cpuinfo_uarch_cortex_x3:
+			return "Cortex-X3";
+		case cpuinfo_uarch_neoverse_n1:
+			return "Neoverse N1";
+		case cpuinfo_uarch_neoverse_e1:
+			return "Neoverse E1";
+		case cpuinfo_uarch_neoverse_v1:
+			return "Neoverse V1";
+		case cpuinfo_uarch_neoverse_n2:
+			return "Neoverse N2";
+		case cpuinfo_uarch_neoverse_v2:
+			return "Neoverse V2";
+		case cpuinfo_uarch_scorpion:
+			return "Scorpion";
+		case cpuinfo_uarch_krait:
+			return "Krait";
+		case cpuinfo_uarch_kryo:
+			return "Kryo";
+		case cpuinfo_uarch_falkor:
+			return "Falkor";
+		case cpuinfo_uarch_saphira:
+			return "Saphira";
+		case cpuinfo_uarch_oryon:
+			return "Oryon";
+		case cpuinfo_uarch_denver:
+			return "Denver";
+		case cpuinfo_uarch_denver2:
+			return "Denver 2";
+		case cpuinfo_uarch_carmel:
+			return "Carmel";
+		case cpuinfo_uarch_exynos_m1:
+			return "Exynos M1";
+		case cpuinfo_uarch_exynos_m2:
+			return "Exynos M2";
+		case cpuinfo_uarch_exynos_m3:
+			return "Exynos M3";
+		case cpuinfo_uarch_exynos_m4:
+			return "Exynos M4";
+		case cpuinfo_uarch_exynos_m5:
+			return "Exynos M5";
+		case cpuinfo_uarch_swift:
+			return "Swift";
+		case cpuinfo_uarch_cyclone:
+			return "Cyclone";
+		case cpuinfo_uarch_typhoon:
+			return "Typhoon";
+		case cpuinfo_uarch_twister:
+			return "Twister";
+		case cpuinfo_uarch_hurricane:
+			return "Hurricane";
+		case cpuinfo_uarch_monsoon:
+			return "Monsoon";
+		case cpuinfo_uarch_mistral:
+			return "Mistral";
+		case cpuinfo_uarch_vortex:
+			return "Vortex";
+		case cpuinfo_uarch_tempest:
+			return "Tempest";
+		case cpuinfo_uarch_lightning:
+			return "Lightning";
+		case cpuinfo_uarch_thunder:
+			return "Thunder";
+		case cpuinfo_uarch_firestorm:
+			return "Firestorm";
+		case cpuinfo_uarch_icestorm:
+			return "Icestorm";
+		case cpuinfo_uarch_avalanche:
+			return "Avalanche";
+		case cpuinfo_uarch_blizzard:
+			return "Blizzard";
+		case cpuinfo_uarch_everest:
+			return "Everest";
+		case cpuinfo_uarch_sawtooth:
+			return "Sawtooth";
+		case cpuinfo_uarch_coll_everest:
+			return "Coll_Everest";
+		case cpuinfo_uarch_coll_sawtooth:
+			return "Coll_Sawtooth";
+		case cpuinfo_uarch_tupai_everest:
+			return "Tupai_Everest";
+		case cpuinfo_uarch_tupai_sawtooth:
+			return "Tupai_Sawtooth";
+		case cpuinfo_uarch_tahiti_everest:
+			return "Tahiti_Everest";
+		case cpuinfo_uarch_tahiti_sawtooth:
+			return "Tahiti_Sawtooth";
+		case cpuinfo_uarch_thunderx:
+			return "ThunderX";
+		case cpuinfo_uarch_thunderx2:
+			return "ThunderX2";
+		case cpuinfo_uarch_pj4:
+			return "PJ4";
+		case cpuinfo_uarch_brahma_b15:
+			return "Brahma B15";
+		case cpuinfo_uarch_brahma_b53:
+			return "Brahma B53";
+		case cpuinfo_uarch_xgene:
+			return "X-Gene";
+		case cpuinfo_uarch_dhyana:
+			return "Dhyana";
+		case cpuinfo_uarch_taishan_v110:
+			return "TaiShan v110";
+		default:
+			return "";
+	}
+}
+
+}


### PR DESCRIPTION
The magic_enum enum_name function is limited to a max range of UINT16_MAX between min and max values, but the CPU Info uarch enum exceeds UINT16_MAX by quite a bit.