### PR TITLE
[Metal] Use device0 stream by default and update test.py

### DIFF
--- a/plugins/metal/metal_runtime.cpp
+++ b/plugins/metal/metal_runtime.cpp
@@ -788,7 +788,12 @@ extern "C" nxs_status nxsRunSchedule(nxs_int schedule_id, nxs_int stream_id, nxs
   auto sched = (*parent)->get<MetalSchedule>(); 
   if (!sched) return NXS_InvalidSchedule;
   auto stream = rt->get<MTL::CommandQueue>(stream_id);
-  if (!stream) return NXS_InvalidStream;
+  if (!stream) {
+    // Invalid stream provided, try the default stream
+    // TODO: should we handle separate device or assume the default stream 
+    // on the first device? should we check for > 0 devices?
+    stream = rt->getQueue(0);
+  }
 
   auto *cmdbuf = sched->getCommandBuffer(rt, *parent, *stream);
   if (!cmdbuf) return NXS_InvalidSchedule;

--- a/test/pynexus/test.py
+++ b/test/pynexus/test.py
@@ -21,9 +21,9 @@ kern = lib.get_kernel('add_vectors')
 sched = dev.create_schedule()
 
 cmd = sched.create_command(kern)
-cmd.set_buffer(0, nb0)
-cmd.set_buffer(1, nb1)
-cmd.set_buffer(2, nb2)
+cmd.set_arg(0, nb0)
+cmd.set_arg(1, nb1)
+cmd.set_arg(2, nb2)
 cmd.finalize(32, 1024)
 
 sched.run()


### PR DESCRIPTION
Updates the metal runtime `run` method to use the default stream if no stream is provided. I did not see a way to get the device ID within the schedule - presumably the device ID would be provided by the stream? So, I think getting the default stream for device 0 makes the most sense. It seems like a good idea to add a check though, to make sure there are > 0 devices and return an error otherwise. What do you think? 

Also updated some of the calls in `test.py` to use new APIs. 