### PR TITLE
Clean up environment variables for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ dist/
 __pycache__/
 *.py[cod]
 .pytest_cache
+python/nexus/device_lib
 
 *.egg-info
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ if(NEXUS_ENABLE_LOGGING)
   add_compile_definitions(NEXUS_LOGGING)
 endif()
 
+file(COPY ${CMAKE_SOURCE_DIR}/device_lib/
+     DESTINATION ${CMAKE_BINARY_DIR}/device_lib
+     FILES_MATCHING PATTERN "*")
+
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/third_party/magic_enum/include)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+graft device_lib
 include CMakeLists.txt
 include *.md *.txt *.cfg *.ini
 recursive-include cmake *.cmake *.in

--- a/python/nexus/__init__.py
+++ b/python/nexus/__init__.py
@@ -4,7 +4,12 @@ __version__ = '0.0.1'
 # ---------------------------------------
 # Note: import order is significant here.
 
-# submodules
+import os
+_NEXUS_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+os.environ['NEXUS_HOME'] = _NEXUS_PACKAGE_DIR
+os.environ['NEXUS_RUNTIME_PATH'] = os.path.join(_NEXUS_PACKAGE_DIR, 'runtime_libs')
+os.environ['NEXUS_DEVICE_PATH'] = os.path.join(_NEXUS_PACKAGE_DIR, 'device_lib')
 
 from ._C.libnexus import *
 

--- a/src/device_db.cpp
+++ b/src/device_db.cpp
@@ -22,7 +22,7 @@ std::vector<std::string> splitPaths(const std::string &paths, char delimiter) {
 }
 
 static bool initDeviceInfoDB(DeviceInfoMap &devs) {
-  iterateEnvPaths("NEXUS_DEVICE_PATH", "../device_lib",
+  iterateEnvPaths("NEXUS_DEVICE_PATH", "./device_lib",
                   [&](const std::string &path, const std::string &name) {
                     NEXUS_LOG(NEXUS_STATUS_NOTE, "  File: " << name);
                     std::string::size_type const p(name.find_last_of('.'));


### PR DESCRIPTION
This PR cleans up the way Nexus handles critical environment paths to be more flexible and enabling release packaging to work