### PR TITLE
Update ubuntu github actions runner to use cuda instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'cuda-runner' || matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
This PR updates the build CI to run ubuntu jobs on the cuda runner