### PR TITLE
Point submodules to original repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git@github.com:Neargye/magic_enum.git
 [submodule "third_party/cpuinfo"]
 	path = third_party/cpuinfo
-	url = git@github.com:alexbaden/cpuinfo.git
+	url = https://github.com/pytorch/cpuinfo.git
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
This commit updates the git submodules to point the upstream submodule references to the official repositories