### PR TITLE
Update CMake to find pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ include_directories(${PROJECT_SOURCE_DIR}/third_party/pybind11_json/include)
 
 # -----
 add_subdirectory(third_party/json json)
+
+set(PYBIND11_FINDPYTHON ON)
 add_subdirectory(third_party/pybind11_json pybind11_json)
 
 # ------


### PR DESCRIPTION
This PR updates the CMake to tell pybind to use modern search for python