### PR TITLE
[rt_pool] Update rt_pool to wrap sub arrays in unique_ptr

### DIFF
--- a/plugins/cpu/cpu_runtime.h
+++ b/plugins/cpu/cpu_runtime.h
@@ -14,9 +14,9 @@ using namespace nxs;
 class CpuRuntime : public rt::Runtime {
   nxs_int numCores;
   ThreadPool threadpool;
-  rt::Pool<rt::Buffer, 256> buffer_pool;
-  rt::Pool<CpuCommand> command_pool;
-  rt::Pool<CpuSchedule, 256> schedule_pool;
+  rt::SynchronizedPmrPool<rt::Buffer> buffer_pool;
+  rt::SynchronizedPmrPool<CpuCommand> command_pool;
+  rt::SynchronizedPmrPool<CpuSchedule> schedule_pool;
 
   nxs_int initNumCores() const {
     cpuinfo_initialize();
@@ -42,37 +42,36 @@ class CpuRuntime : public rt::Runtime {
 
   rt::Buffer *getBuffer(nxs_buffer_layout shape, void *data_ptr = nullptr,
                         nxs_uint settings = 0) {
-    return buffer_pool.get_new(shape, data_ptr, settings);
+    return buffer_pool.construct(shape, data_ptr, settings);
   }
 
   nxs_status releaseBuffer(nxs_int buffer_id) {
     auto buf = get<rt::Buffer>(buffer_id);
     if (!buf) return NXS_InvalidBuffer;
-    buffer_pool.release(buf);
+    buffer_pool.destroy(buf);
     if (!dropObject(buffer_id)) return NXS_InvalidBuffer;
     return NXS_Success;
   }
 
   nxs_int getSchedule(nxs_int device_id, nxs_uint settings = 0) {
-    auto schedule = schedule_pool.get_new(device_id, settings);
-    if (!schedule) return NXS_InvalidSchedule;
+    auto *schedule = schedule_pool.construct(device_id, settings);
     return addObject(schedule);
   }
 
   CpuCommand *getCommand(cpuFunction_t kernel, nxs_uint settings = 0) {
-    return command_pool.get_new(this, kernel, settings);
+    return command_pool.construct(this, kernel, settings);
   }
 
   CpuCommand *getCommand(nxs_int event, nxs_command_type type,
                          nxs_int event_value = 0, nxs_uint settings = 0) {
-    return command_pool.get_new(this, event, type, event_value, settings);
+    return command_pool.construct(this, event, type, event_value, settings);
   }
 
   nxs_status releaseCommand(nxs_int command_id) {
     auto cmd = get<CpuCommand>(command_id);
     if (!cmd) return NXS_InvalidCommand;
     // cmd->release();
-    command_pool.release(cmd);
+    command_pool.destroy(cmd);
     if (!dropObject(command_id)) return NXS_InvalidCommand;
     return NXS_Success;
   }
@@ -84,7 +83,7 @@ class CpuRuntime : public rt::Runtime {
       // releaseCommand(cmd->getId());
     }
     sched->release();
-    schedule_pool.release(sched);
+    schedule_pool.destroy(sched);
     if (!dropObject(schedule_id)) return NXS_InvalidSchedule;
     return NXS_Success;
   }

--- a/plugins/include/rt_pool.h
+++ b/plugins/include/rt_pool.h
@@ -3,6 +3,7 @@
 
 #include <nexus-api.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -22,7 +23,8 @@ template <typename T, size_t chunk_size = 1024>
 class Pool {
  private:
   typedef std::array<T, chunk_size> Chunk;
-  std::vector<Chunk> object_storage_;       // Owns all objects
+  // unique_ptr keeps chunk storage stable when this vector grows (raw pointers in rt::Runtime)
+  std::vector<std::unique_ptr<Chunk>> object_storage_;
   std::vector<nxs_int> available_indices_;  // Indices of available objects
   std::mutex pool_mutex_;
   nxs_int tail_index_;
@@ -32,14 +34,16 @@ class Pool {
     return {index / chunk_size, index % chunk_size};
   }
 
-  Chunk& getChunk(nxs_int index) { return object_storage_[index]; }
+  Chunk& getChunk(nxs_int index) { return *object_storage_[index]; }
 
  public:
   /**
    * Constructor
    * @param initial_capacity Initial capacity for the pool
    */
-  explicit Pool() : tail_index_(0) { object_storage_.push_back(Chunk()); }
+  explicit Pool() : tail_index_(0) {
+    object_storage_.push_back(std::make_unique<Chunk>());
+  }
 
   ~Pool() { clear(); }
 
@@ -63,7 +67,7 @@ class Pool {
 
     auto [chunk_index, chunk_offset] = getIndexPair(tail_index_);
     if (chunk_index >= object_storage_.size()) {
-      object_storage_.push_back(Chunk());
+      object_storage_.push_back(std::make_unique<Chunk>());
     }
     auto& chunk = getChunk(chunk_index);
     new (&chunk[chunk_offset]) T(std::forward<Args>(args)...);
@@ -85,16 +89,16 @@ class Pool {
 
     std::lock_guard<std::mutex> lock(pool_mutex_);
 
-    // Find the index of the object
-    nxs_int chunk_index = 0;
-    for (auto& chunk : object_storage_) {
-      auto chunk_offset = obj - &chunk[0];
-      if (chunk_offset >= 0 && chunk_offset < chunk_size) {
+    // Resolve by pool slot index, not pointer arithmetic across chunks. Chunk
+    // base + offset checks can still misbehave with separate allocations; and
+    // comparing get(i) == obj is the definitive identity for placement-new slots.
+    // O(tail_index_) — acceptable for current pool sizes; can add a side map later.
+    for (nxs_int i = 0; i < tail_index_; ++i) {
+      if (get(i) == obj) {
         // obj->~T();
-        available_indices_.push_back(chunk_index * chunk_size + chunk_offset);
+        available_indices_.push_back(i);
         return;
       }
-      chunk_index++;
     }
   }
 
@@ -167,8 +171,10 @@ class Pool {
   bool owns_object(const T* obj) {
     if (!obj) return false;
     std::lock_guard<std::mutex> lock(pool_mutex_);
-    return obj >= &object_storage_[0] &&
-           obj < &object_storage_[0] + object_storage_.size();
+    for (nxs_int i = 0; i < tail_index_; ++i) {
+      if (get(i) == obj) return true;
+    }
+    return false;
   }
 };
 

--- a/plugins/include/rt_pool.h
+++ b/plugins/include/rt_pool.h
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <functional>
 #include <memory>
+#include <memory_resource>
 #include <mutex>
 #include <queue>
 #include <vector>
@@ -175,6 +176,34 @@ class Pool {
       if (get(i) == obj) return true;
     }
     return false;
+  }
+};
+
+
+template <typename T>
+class SynchronizedPmrPool {
+  std::pmr::synchronized_pool_resource synchronized_resource;
+  std::pmr::polymorphic_allocator<T> allocator;
+
+ public:
+  SynchronizedPmrPool() : allocator(&synchronized_resource) {}
+
+  template <typename... Args>
+  T *construct(Args &&...args) {
+    T *p = allocator.allocate(1);
+    try {
+      ::new (static_cast<void *>(p)) T(std::forward<Args>(args)...);
+    } catch (...) {
+      allocator.deallocate(p, 1);
+      throw;
+    }
+    return p;
+  }
+
+  void destroy(T *p) {
+    if (!p) return;
+    p->~T();
+    allocator.deallocate(p, 1);
   }
 };
 


### PR DESCRIPTION
Currently when object_storage in pool increases the previous allocations can be relocated resulting in a segmentation fault (for example with triton 02 tutorial, which allocates more than a 1000 Schedule objects for perf benchmarking) 

This change wraps the arrays in a unique_ptr creating an indirection to keep raw pointer addresses stable.

#134 